### PR TITLE
dinput8

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,4 +40,6 @@ jobs:
           automatic_release_tag: "latest"
           prerelease: false
           title: "Latest Build"
-          files: bin/Release/azop.dll
+          files: |
+            bin/Release/azop.dll
+            bin/Release/azop.pdb

--- a/.gitmodules
+++ b/.gitmodules
@@ -10,9 +10,6 @@
 [submodule "ext/LR2Mem"]
 	path = ext/LR2Mem
 	url = https://github.com/MatVeiQaaa/LR2Mem.git
-[submodule "ext/StackWalker"]
-	path = ext/StackWalker
-	url = https://github.com/JochenKalmbach/StackWalker.git
 [submodule "ext/json"]
 	path = ext/json
 	url = https://github.com/nlohmann/json.git

--- a/src/ImGuiInjector/ImGuiInjector.cpp
+++ b/src/ImGuiInjector/ImGuiInjector.cpp
@@ -3,7 +3,7 @@
 #include <iostream>
 #include <windows.h>
 
-#include "Helpers/Helpers.hpp"
+#include <Helpers/Helpers.hpp>
 #include "imgui/imgui.h"
 #include <imgui_internal.h>
 #include "kiero/kiero.h"
@@ -102,9 +102,14 @@ bool HookDinput7(HMODULE hModule) {
         LPVOID* ppvOut,
         LPUNKNOWN punkOuter);
     tDirectInputCreateEx DirectInputCreateEx = (tDirectInputCreateEx)GetProcAddress(hModule, "DirectInputCreateEx");
+    if (DirectInputCreateEx == nullptr) {
+        std::cout << "DirectInputCreateEx of dinput.dll not found\n" << std::flush;
+        return false;
+    }
+
     GUID IID_IDirectInput7A = { 0x9A4CB684,0x236D,0x11D3,0x8E,0x9D,0x00,0xC0,0x4F,0x68,0x44,0xAE };
     if (DirectInputCreateEx(GetModuleHandle(NULL), DIRECTINPUT_VERSION, IID_IDirectInput7A, (LPVOID*)&pDirectInput, NULL) != DI_OK) {
-        std::cout << "DirectInputCreateEx failed" << std::endl;
+        std::cout << "DirectInputCreateEx failed\n" << std::flush;
         return false;
     }
 
@@ -113,24 +118,23 @@ bool HookDinput7(HMODULE hModule) {
     GUID IID_IDirectInputDevice7A = { 0x57D7C6BC,0x2356,0x11D3,0x8E,0x9D,0x00,0xC0,0x4F,0x68,0x44,0xAE };
     if (pDirectInput->CreateDeviceEx(GUID_SysMouse, IID_IDirectInputDevice7A, (LPVOID*)&lpdiMouse, NULL) != DI_OK) {
         pDirectInput->Release();
-        std::cout << "Error creating DirectInput device" << std::endl;
+        std::cout << "Error creating DirectInput device\n" << std::flush;
         return false;
     }
 
     uintptr_t vTable = mem::FindDMAAddy((uintptr_t)lpdiMouse, { 0x0 });
-
     
     GetDeviceState = (tGetDeviceState)(((char**)vTable)[9]);
 
     if (MH_CreateHookEx((LPVOID)GetDeviceState, &OnGetDeviceState, &GetDeviceState) != MH_OK)
     {
-        std::cout << "Couldn't hook GetDeviceState" << std::endl;
+        std::cout << "Couldn't hook GetDeviceState\n" << std::flush;
         return false;
     }
 
     if (MH_QueueEnableHook(MH_ALL_HOOKS) || MH_ApplyQueued() != MH_OK)
     {
-        std::cout << ("Couldn't enable dinput hooks");
+        std::cout << "Couldn't enable dinput hooks\n" << std::flush;
         return 1;
     }
 
@@ -151,7 +155,7 @@ void ImGuiInjector::HookDinput() {
         HookDinput7(dinputHandle7);
         break;
     }
-    case 8: std::cout << "Dinput8 hooking is unimplemented" << std::endl; break;
+    case 8: std::cout << "Dinput8 hooking is unimplemented\n" << std::flush; break;
     default: break;
     }
 }
@@ -274,8 +278,8 @@ void ImGuiInjector::LoadJapaneseFont() {
     try {
         io.Fonts->AddFontFromFileTTF("C:\\Windows\\Fonts\\msgothic.ttc", 16.0f, nullptr, io.Fonts->GetGlyphRangesChineseFull());
     }
-    catch (...) {
-        std::cout << "Couldn't load font at path C:\\Windows\\Fonts\\msgothic.ttc" << std::endl;
+    catch (const std::exception& e) {
+        std::cout << "Couldn't load font at path C:\\Windows\\Fonts\\msgothic.ttc: " << e.what() << "\n" << std::flush;
     }
 }
 

--- a/src/LR2HackBox/Features/AnalogInput.cpp
+++ b/src/LR2HackBox/Features/AnalogInput.cpp
@@ -1,16 +1,16 @@
 #define NOMINMAX
 #include "AnalogInput.hpp"
 
-#include <iostream>
 #include <cstdlib>
 #include <algorithm>
 #include "LR2HackBox/LR2HackBox.hpp"
+#include "LogConsole.hpp"
 
 #define DIRECTINPUT_VERSION 0x0700
 #include <dinput.h>
 #include "Helpers/Helpers.hpp"
 
-#include "imgui/imgui.h"
+#include <imgui/imgui.h>
 #include <safetyhook.hpp>
 
 typedef double(__cdecl* tGetTimeWrap)();
@@ -207,7 +207,9 @@ int __cdecl AnalogInput::OnInputToButton(void* is, void* cfg_input, int player, 
 }
 
 bool AnalogInput::Init(uintptr_t moduleBase) {
-	AnalogInput::mModuleBase = moduleBase;
+    AnalogInput::mModuleBase = moduleBase;
+
+    // FIXME: LR2 uses dinput8.dll if dinput.dll is missing.
 
     IDirectInput7* pDirectInput = NULL;
     typedef HRESULT(__stdcall* tDirectInputCreateEx)(HINSTANCE hinst,
@@ -216,9 +218,14 @@ bool AnalogInput::Init(uintptr_t moduleBase) {
         LPVOID* ppvOut,
         LPUNKNOWN punkOuter);
     tDirectInputCreateEx DirectInputCreateEx = (tDirectInputCreateEx)GetProcAddress(GetModuleHandle("dinput.dll"), "DirectInputCreateEx");
+    if (DirectInputCreateEx == nullptr) {
+        LogConsole::AddLog(LOG_ERROR, "DirectInputCreateEx of dinput.dll not found");
+        return false;
+    }
+
     GUID IID_IDirectInput7A = { 0x9A4CB684,0x236D,0x11D3,0x8E,0x9D,0x00,0xC0,0x4F,0x68,0x44,0xAE };
     if (DirectInputCreateEx(GetModuleHandle(NULL), DIRECTINPUT_VERSION, IID_IDirectInput7A, (LPVOID*)&pDirectInput, NULL) != DI_OK) {
-        std::cout << "DirectInputCreateEx failed" << std::endl;
+        LogConsole::AddLog(LOG_ERROR, "DirectInputCreateEx failed");
         return false;
     }
 
@@ -227,7 +234,7 @@ bool AnalogInput::Init(uintptr_t moduleBase) {
     GUID IID_IDirectInputDevice7A = { 0x57D7C6BC,0x2356,0x11D3,0x8E,0x9D,0x00,0xC0,0x4F,0x68,0x44,0xAE };
     if (pDirectInput->CreateDeviceEx(GUID_SysMouse, IID_IDirectInputDevice7A, (LPVOID*)&lpdiMouse, NULL) != DI_OK) {
         pDirectInput->Release();
-        std::cout << "Error creating DirectInput device" << std::endl;
+        LogConsole::AddLog(LOG_ERROR, "Error creating DirectInput device");
         return false;
     }
 


### PR DESCRIPTION
Not proper support, but at least don't crash when LR2 uses dinput8.dll (`WINEDLLOVERRIDES=dinput=`).