### PR TITLE
fix(ScoreCannon): ceil instead of truncating minimal score for grade 

### DIFF
--- a/src/LR2HackBox/Features/ScoreCannon.cpp
+++ b/src/LR2HackBox/Features/ScoreCannon.cpp
@@ -1,6 +1,7 @@
 #define NOMINMAX
 #include "ScoreCannon.hpp"
 
+#include <format>
 #include <print>
 #include <codecvt>
 #include <exception>
@@ -52,7 +53,7 @@ static std::string s2utf(const std::string& str) {
 	return ws2utf(s2ws(str));
 }
 
-static const std::string GetLampText(const ScoreCannon::Score& score) {
+static std::string GetLampText(const ScoreCannon::Score& score) {
 	if (score.lampBest == ScoreCannon::Score::Lamp::NONE) {
 		return ":fireworks: First play!";
 	}
@@ -67,7 +68,7 @@ static const std::string GetLampText(const ScoreCannon::Score& score) {
 	}
 }
 
-static const unsigned int GetLampRGB(const ScoreCannon::Score& score) {
+static unsigned int GetLampRGB(const ScoreCannon::Score& score) {
 	switch (score.lamp) {
 	case ScoreCannon::Score::Lamp::FAILED:
 		return RGB(138,0,0);
@@ -92,25 +93,19 @@ static const unsigned int GetLampRGB(const ScoreCannon::Score& score) {
 	}
 }
 
-static const std::string GetDelta(const int& val1, const int& val2) {
-	int delta = val1 - val2;
-	if (delta >= 0) {
-		return std::format("+{}", delta);
-	}
-	else {
-		return std::to_string(delta);
-	}
+static std::string GetDelta(const int val1, const int val2) {
+    return std::format("{:+}", val1 - val2);
 }
 
-static const std::string GetDeltaNotation(const int& val1, const int& val2) {
+static const char* GetDeltaNotation(const int val1, const int val2) {
 	return val1 != val2 ? val1 > val2 ? ":arrow_up:" : ":arrow_down:" : ":arrow_right:";
 }
 
-static const float GetExPercentage(const int& exScore, const int& exScoreMax) {
+static float GetExPercentage(const int exScore, const int exScoreMax) {
 	return static_cast<float>(exScore) / exScoreMax * 100.f;
 }
 
-static const std::string GetExGradeDelta(const int& exScore, const int& exScoreMax) {
+static std::string GetExGradeDelta(const int exScore, const int exScoreMax) {
 	float score = static_cast<float>(exScore);
 	float scoreMax = static_cast<float>(exScoreMax);
 	Grade gradeNotation(F);
@@ -151,7 +146,7 @@ static const std::string GetExGradeDelta(const int& exScore, const int& exScoreM
 	return std::format("{}{}", grades[gradeNotation], GetDelta(score, gradeScore));
 }
 
-static const Grade GetExGrade(const int& exScore, const int& exScoreMax) {
+static Grade GetExGrade(const int exScore, const int exScoreMax) {
 	float score = static_cast<float>(exScore);
 	float scoreMax = static_cast<float>(exScoreMax);
 	if (exScore == exScoreMax) {

--- a/src/LR2HackBox/Features/ScoreCannon.cpp
+++ b/src/LR2HackBox/Features/ScoreCannon.cpp
@@ -1,6 +1,7 @@
 #define NOMINMAX
 #include "ScoreCannon.hpp"
 
+#include <cmath>
 #include <format>
 #include <print>
 #include <codecvt>
@@ -100,38 +101,38 @@ static std::string GetExGradeDelta(const int exScore, const int exScoreMax) {
 	float score = static_cast<float>(exScore);
 	float scoreMax = static_cast<float>(exScoreMax);
 	Grade gradeNotation(F);
-	int gradeScore = 0;
+	int minGradeScore = 0;
 	if (score / scoreMax > 8.5f / 9.f) {
 		gradeNotation = MAX;
-		gradeScore = scoreMax;
+		minGradeScore = scoreMax;
 	}
 	else if (score / scoreMax > 7.5f / 9.f) {
 		gradeNotation = AAA;
-		gradeScore = static_cast<int>(scoreMax * 8.f / 9.f);
+		minGradeScore = std::ceil(scoreMax * 8.f / 9.f);
 	}
 	else if (score / scoreMax > 6.5f / 9.f) {
 		gradeNotation = AA;
-		gradeScore = static_cast<int>(scoreMax * 7.f / 9.f);
+		minGradeScore = std::ceil(scoreMax * 7.f / 9.f);
 	}
 	else if (score / scoreMax > 5.5f / 9.f) {
 		gradeNotation = A;
-		gradeScore = static_cast<int>(scoreMax * 6.f / 9.f);
+		minGradeScore = std::ceil(scoreMax * 6.f / 9.f);
 	}
 	else if (score / scoreMax > 4.5f / 9.f) {
 		gradeNotation = B;
-		gradeScore = static_cast<int>(scoreMax * 5.f / 9.f);
+		minGradeScore = std::ceil(scoreMax * 5.f / 9.f);
 	}
 	else if (score / scoreMax > 3.5f / 9.f) {
 		gradeNotation = C;
-		gradeScore = static_cast<int>(scoreMax * 4.f / 9.f);
+		minGradeScore = std::ceil(scoreMax * 4.f / 9.f);
 	}
 	else if (score / scoreMax > 2.5f / 9.f) {
 		gradeNotation = D;
-		gradeScore = static_cast<int>(scoreMax * 3.f / 9.f);
+		minGradeScore = std::ceil(scoreMax * 3.f / 9.f);
 	}
 	else {
 		gradeNotation = E;
-		gradeScore = static_cast<int>(scoreMax * 2.f / 9.f);
+		minGradeScore = std::ceil(scoreMax * 2.f / 9.f);
 	}
 
 	return std::format("{}{}", grades[gradeNotation], GetDelta(score, gradeScore));

--- a/src/LR2HackBox/Features/ScoreCannon.cpp
+++ b/src/LR2HackBox/Features/ScoreCannon.cpp
@@ -80,17 +80,8 @@ static unsigned int GetLampRGB(const ScoreCannon::Score& score) {
 		return RGB(254,54,54);
 	case ScoreCannon::Score::Lamp::FULLCOMBO:
 		return RGB(120,255,247);
-	case ScoreCannon::Score::Lamp::PERFECT:
-		return RGB(251,230,255);
-	case ScoreCannon::Score::Lamp::MAX:
-		return RGB(255,255,255);
-	case ScoreCannon::Score::Lamp::NOPLAY:
-		return RGB(127,127,127);
-	case ScoreCannon::Score::Lamp::ASSISTCLEAR:
-		return RGB(37,150,190);
-	default:
-		return 0;
 	}
+	return 0;
 }
 
 static std::string GetDelta(const int val1, const int val2) {

--- a/src/LR2HackBox/Features/ScoreCannon.hpp
+++ b/src/LR2HackBox/Features/ScoreCannon.hpp
@@ -13,10 +13,6 @@ public:
 			GROOVECLEAR,
 			HARDCLEAR,
 			FULLCOMBO,
-			PERFECT,
-			MAX,
-			ASSISTCLEAR,
-			NONE
 		};
 		enum Target {
 			NOTARGET,


### PR DESCRIPTION
This matches LR2 less now, but is ultimately more correct.